### PR TITLE
Add QR Description

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "prawn", "~> 2.4"

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -1,4 +1,7 @@
 require 'rqrcode'
+require 'prawn'
+require 'stringio'
+
 class ShipmentsController < ApplicationController
   def new
     @shipment = Shipment.new
@@ -118,7 +121,12 @@ class ShipmentsController < ApplicationController
   def qr
     @shipment = Shipment.find(params[:shipment_id])
     authorize @shipment
-    send_data RQRCode::QRCode.new(new_shipment_scan_url(@shipment.exid)).as_png(size: 800), type: 'image/png', disposition: 'attachment'
+    qrCode = RQRCode::QRCode.new(new_shipment_scan_url(@shipment.exid)).as_png(size: 800)
+    qrPdf = Prawn::Document.new
+    qrPdf.text "Shipment #{@shipment.exid} from #{@shipment.starting_location} to #{@shipment.destination_location}"
+    qrPdf.image StringIO.new(qrCode)
+    
+    send_data qrPdf.render(), type: 'application/pdf', disposition: 'attachment'
   end
 
   private

--- a/app/controllers/shipments_controller.rb
+++ b/app/controllers/shipments_controller.rb
@@ -128,7 +128,8 @@ class ShipmentsController < ApplicationController
     qrCode.save(qrCodeFilename)
 
     qrPdf = Prawn::Document.new
-    qrPdf.text "Shipment #{@shipment.exid} from #{@shipment.starting_location} to #{@shipment.destination_location}"
+    qrPdf.text "Shipment #{@shipment.exid}"
+    qrPdf.text "#{@shipment.starting_location} to #{@shipment.destination_location}"
     qrPdf.image qrCodeFilename
     
     send_data qrPdf.render(), type: 'application/pdf', disposition: 'attachment'


### PR DESCRIPTION
Fixes #89 by:

- Adding shipment meta data to the QR code printout.
- Opening the QR code in a new tab rather than downloading it directly to the user device.

![image](https://user-images.githubusercontent.com/1821099/224324578-b746a737-454e-4642-b43e-a1ba2f206434.png)
